### PR TITLE
sqlite: Export headers to other libraries

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -35,7 +35,7 @@
 ################################################################################
 # App registration
 ################################################################################
-$(eval $(call addlib,libsqlite))
+$(eval $(call addlib,libsqlite,$(CONFIG_LIBSQLITE)))
 
 ################################################################################
 # Sources
@@ -56,7 +56,8 @@ LIBSQLITE_SRC = $(LIBSQLITE_ORIGIN)/$(LIBSQLITE_BASENAME)
 # Library includes
 ################################################################################
 LIBSQLITE_CINCLUDES-y += -I$(LIBSQLITE_BASE)/include
-LIBSQLITE_CINCLUDES += -I$(LIBSQLITE_SRC)
+CINCLUDES-$(CONFIG_LIBSQLITE) += -I$(LIBSQLITE_SRC)
+CXXINCLUDES-$(CONFIG_LIBSQLITE) += -I$(LIBSQLITE_SRC)
 
 ################################################################################
 # Global flags


### PR DESCRIPTION
Other external libraries such as Python might want to use the SQLite
C API. In this patch, we make the headers available to other libraries.
Further, we add a fix to register the library only if the config
option is selected

Signed-off-by: Vlad-Andrei Badoiu <vlad_andrei.badoiu@upb.ro>