### PR TITLE
Porting sqlite TH3 tests into uktests. 

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -7,7 +7,18 @@ menuconfig LIBSQLITE
     select LIBPTHREAD_EMBEDDED
 
 if LIBSQLITE
-config LIBSQLITE_MAIN_FUNCTION
-    bool "Provide main function"
-    default y
+    config LIBSQLITE_MAIN_FUNCTION
+        bool "Provide main function"
+        default y
+    config LIBSQLITE_TEST
+        bool "Enable sqlite tcl tests"
+        select LIBUKTEST
+        default n
+        select LIBSQLITE_TEST_MINIMAL
+        help
+
+    config LIBSQLITE_TEST_MINIMAL
+        bool
+        default n
+
 endif

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -85,3 +85,11 @@ LIBSQLITE_SHELL_FLAGS-y += -Dmain=sqlite_main -Dwmain=sqlite_main
 
 LIBSQLITE_SRCS-y += $(LIBSQLITE_SRC)/shell.c
 LIBSQLITE_SRCS-y += $(LIBSQLITE_SRC)/sqlite3.c
+
+
+################################################################################
+# Tests
+################################################################################
+ifneq ($(filter y, $(LIBSQLITE_TEST_MINIMAL) $(CONFIG_LIBUKTEST_ALL)),)
+LIBSQLITE_SRCS-y += $(LIBSQLITE_BASE)/tests/test_minimal.c
+endif


### PR DESCRIPTION
## Port some of the tests from sqlite TH3 into uktests

### Progress
- [x] Tested sqlite internal tests locally using makefile rules from the official repo
- [x] Added config options into Config.uk as seen in PRs such as https://github.com/unikraft/lib-mimalloc/pull/3
- [ ] Use the script (mkth3.tcl) mention in this link in section 3 to generate 100% C code that can be linked against the sqlite [amalgamation](https://www.sqlite.org/th3.html) and run locally.
- [ ] Port one test
- [ ] Port all of the quick tests
- [ ] Update documentation and maintaining TODOs

### Blockers
For some reason I cannot find the mkth3.tcl script that is referenced on the official site although I looked intensively for it on Github. If you have any advice, it would be very welcome, otherwise I'll keep this draft PR updated if I can move forward.
 