### PR TITLE
Config.uk: Fix dependency issues & defaults

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -9,5 +9,5 @@ menuconfig LIBSQLITE
 if LIBSQLITE
 config LIBSQLITE_MAIN_FUNCTION
     bool "Provide main function"
-    default y
+    default n
 endif

--- a/Config.uk
+++ b/Config.uk
@@ -1,9 +1,9 @@
 menuconfig LIBSQLITE
     bool "SQLite"
-    default y
-    select LIBUKMMAP
+    default n
+    imply LIBUKMMAP
     select LIBPOSIX_SYSINFO
-    select LIBNEWLIBC
+    depends on HAVE_LIBC
     select LIBPTHREAD_EMBEDDED
 
 if LIBSQLITE


### PR DESCRIPTION
Unless specifically required (like by app-sqlite) the main function should not be provided by default; lib-sqlite should also not be enabled by default if included (in line with other libs)
In addition, remove the hard select of UKMMAP and LIBNEWLIBC, allowing the use of posix-mmap & musl.

edit: Added new commit, renamed to be more descriptive of issues fixed