### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "sqlite"
+description := "A C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine."
+gitrepo     := "https://github.com/sqlite/sqlite.git"
+homepage    := "https://www.sqlite.org/"
+license     := "blessing"
+version     := 3400100 sha256:49112cc7328392aa4e3e5dae0b2f6736d0153430143d21f69327788ff4efe734 https://www.sqlite.org/2022/sqlite-amalgamation-3400100.zip


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

