### PR TITLE
Update SQLite to version 3.50.1 and ensure Unikraft compatibility

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,13 +1,11 @@
 menuconfig LIBSQLITE
-    bool "SQLite"
+    bool "libsqlite"
     default n
-    imply LIBUKMMAP
-    select LIBPOSIX_SYSINFO
-    depends on HAVE_LIBC
-    select LIBPTHREAD_EMBEDDED
+    help
+      Enable the SQLite library
 
 if LIBSQLITE
-config LIBSQLITE_MAIN_FUNCTION
-    bool "Provide main function"
-    default n
+config LIBSQLITE_ENABLE_SOMETHING
+    bool "Some internal sqlite config"
+    default y
 endif

--- a/Config.uk
+++ b/Config.uk
@@ -4,8 +4,12 @@ menuconfig LIBSQLITE
     help
       Enable the SQLite library
 
+config LIBSQLITE_ENABLE_SHELL
+    bool "Enable SQLite shell (CLI) interface"
+    default n
+
 if LIBSQLITE
-config LIBSQLITE_ENABLE_SOMETHING
-    bool "Some internal sqlite config"
-    default y
+config LIBSQLITE_MAIN_FUNCTION
+    bool "Provide main function"
+    default n
 endif

--- a/Config.uk
+++ b/Config.uk
@@ -1,3 +1,8 @@
+imply LIBUKMMAP
+select LIBPOSIX_SYSINFO
+depends on HAVE_LIBC
+select LIBPTHREAD_EMBEDDED
+
 menuconfig LIBSQLITE
     bool "libsqlite"
     default n

--- a/Library.uk
+++ b/Library.uk
@@ -3,6 +3,5 @@ description := "A C-language library that implements a small, fast, self-contain
 gitrepo     := "https://github.com/sqlite/sqlite.git"
 homepage    := "https://www.sqlite.org/"
 license     := "blessing"
-version     := 3500100 \
-sha256:41716b44ac8777188c4c3f1f370f01c9cb9e3b6428eb5c981d086c35de2d9d3f https://www.sqlite.org/2025/sqlite-amalgamation-3500100.zip
+version     := 3500100 sha256:41716b44ac8777188c4c3f1f370f01c9cb9e3b6428eb5c981d086c35de2d9d3f https://www.sqlite.org/2025/sqlite-amalgamation-3500100.zip
 

--- a/Library.uk
+++ b/Library.uk
@@ -1,9 +1,9 @@
 name        := "libsqlite"
-description := "A C-language library that implements a small, fast, self-contained SQL database engine."
+description := "A C-language library that implements a small, fast, self-contained SQL database engine"
 gitrepo     := "https://github.com/sqlite/sqlite.git"
 homepage    := "https://www.sqlite.org/"
 license     := "blessing"
-version     := 3450300
-hash        := sha256:49112cc7328392aa4e3e5dae0b2f6736d0153430143d21f69327...
+version     := 3500100
+hash        := sha256:41716b44ac8777188c4c3f1f370f01c9cb9e3b6428eb5c981d086c35de2d9d3f
 
 $(eval $(call addlib_s,libsqlite,$(CONFIG_LIBSQLITE)))

--- a/Library.uk
+++ b/Library.uk
@@ -1,9 +1,8 @@
-name        := "libsqlite"
+name        := "sqlite"
 description := "A C-language library that implements a small, fast, self-contained SQL database engine"
 gitrepo     := "https://github.com/sqlite/sqlite.git"
 homepage    := "https://www.sqlite.org/"
 license     := "blessing"
-version     := 3500100
-hash        := sha256:41716b44ac8777188c4c3f1f370f01c9cb9e3b6428eb5c981d086c35de2d9d3f
+version     := 3500100 \
+sha256:41716b44ac8777188c4c3f1f370f01c9cb9e3b6428eb5c981d086c35de2d9d3f https://www.sqlite.org/2025/sqlite-amalgamation-3500100.zip
 
-$(eval $(call addlib_s,libsqlite,$(CONFIG_LIBSQLITE)))

--- a/Library.uk
+++ b/Library.uk
@@ -1,6 +1,9 @@
-name        := "sqlite"
-description := "A C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine."
+name        := "libsqlite"
+description := "A C-language library that implements a small, fast, self-contained SQL database engine."
 gitrepo     := "https://github.com/sqlite/sqlite.git"
 homepage    := "https://www.sqlite.org/"
 license     := "blessing"
-version     := 3400100 sha256:49112cc7328392aa4e3e5dae0b2f6736d0153430143d21f69327788ff4efe734 https://www.sqlite.org/2022/sqlite-amalgamation-3400100.zip
+version     := 3450300
+hash        := sha256:49112cc7328392aa4e3e5dae0b2f6736d0153430143d21f69327...
+
+$(eval $(call addlib_s,libsqlite,$(CONFIG_LIBSQLITE)))

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -37,11 +37,11 @@
 $(eval $(call addlib_s,libsqlite,$(CONFIG_LIBSQLITE)))
 
 ################################################################################
-# Versioning and Paths
+# Sources
 ################################################################################
-LIBSQLITE_VERSION = 3450300
+LIBSQLITE_VERSION = 3500100
 LIBSQLITE_BASENAME = sqlite-amalgamation-$(LIBSQLITE_VERSION)
-LIBSQLITE_URL = https://www.sqlite.org/2024/$(LIBSQLITE_BASENAME).zip
+LIBSQLITE_URL = https://www.sqlite.org/2025/$(LIBSQLITE_BASENAME).zip
 LIBSQLITE_PATCHDIR           = $(LIBSQLITE_BASE)/patches
 LIBSQLITE_SRC                = $(LIBSQLITE_ORIGIN)/$(LIBSQLITE_BASENAME)
 
@@ -49,10 +49,10 @@ $(eval $(call fetch,libsqlite,$(LIBSQLITE_URL)))
 $(eval $(call patch,libsqlite,$(LIBSQLITE_PATCHDIR),$(LIBSQLITE_BASENAME)))
 
 ################################################################################
-# Includes
+# Library includes
 ################################################################################
-CINCLUDES-$(CONFIG_LIBSQLITE)  += -I$(LIBSQLITE_SRC)
-CINCLUDES-$(CONFIG_LIBSQLITE)  += -I$(LIBSQLITE_BASE)/include
+LIBSQLITE_CINCLUDES-y += -I$(LIBSQLITE_BASE)/include
+CINCLUDES-$(CONFIG_LIBSQLITE) += -I$(LIBSQLITE_SRC)
 CXXINCLUDES-$(CONFIG_LIBSQLITE) += -I$(LIBSQLITE_SRC)
 
 ################################################################################
@@ -65,6 +65,7 @@ LIBSQLITE_FLAGS = -D_HAVE_SQLITE_CONFIG_H \
                   -DSQLITE_OS_OTHER=1 \
                   -DSQLITE_THREADSAFE=0
 
+# Suppress some warnings to make the build process look neater
 LIBSQLITE_SUPPRESS_FLAGS-y += -Wno-unused-parameter \
                               -Wno-unused-variable \
                               -Wno-cast-function-type \
@@ -72,25 +73,25 @@ LIBSQLITE_SUPPRESS_FLAGS-y += -Wno-unused-parameter \
 
 LIBSQLITE_SUPPRESS_FLAGS-$(call gcc_version_ge,7,0) += -Wimplicit-fallthrough=0
 
-CFLAGS-$(CONFIG_LIBSQLITE) += $(LIBSQLITE_FLAGS)
-CFLAGS-$(CONFIG_LIBSQLITE) += $(LIBSQLITE_SUPPRESS_FLAGS-y)
+LIBSQLITE_CFLAGS-y += $(LIBSQLITE_FLAGS)
+LIBSQLITE_CFLAGS-y += $(LIBSQLITE_SUPPRESS_FLAGS-y)
 
 ################################################################################
 # Sources
 ################################################################################
 LIBSQLITE_SRCS-y += $(LIBSQLITE_SRC)/sqlite3.c
+LIBSQLITE_SRCS-$(CONFIG_LIBSQLITE_ENABLE_SHELL) += $(LIBSQLITE_SRC)/shell.c
 
 # Optional: Shell support (CLI app interface, not needed for lib use)
-# Uncomment only if your app needs the shell interface (usually not)
-# LIBSQLITE_CFLAGS-y += -Dmain=sqlite_main -Dwmain=sqlite_main
-# LIBSQLITE_SRCS-y   += $(LIBSQLITE_SRC)/shell.c
+LIBSQLITE_CFLAGS-y += -Dmain=sqlite_main -Dwmain=sqlite_main
+LIBSQLITE_SRCS-y   += $(LIBSQLITE_SRC)/shell.c
 
 # Optional: Dummy main.c to satisfy Unikraft if needed
-# (Used only if library wants to override main())
-# LIBSQLITE_SRCS-$(CONFIG_LIBSQLITE_MAIN_FUNCTION) += $(LIBSQLITE_BASE)/main.c
+LIBSQLITE_SRCS-$(CONFIG_LIBSQLITE_MAIN_FUNCTION) += $(LIBSQLITE_BASE)/main.c
 
 ################################################################################
 # Object generation
 ################################################################################
 LIBSQLITE_OBJS-y := $(LIBSQLITE_SRCS-y:.c=.o)
 $(eval $(call addlibobjs,libsqlite,$(LIBSQLITE_OBJS-y)))
+$(eval $(call addlib_s,libsqlite,$(CONFIG_LIBSQLITE)))

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -30,7 +30,6 @@
 #  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
-#
 
 ################################################################################
 # App registration
@@ -38,50 +37,60 @@
 $(eval $(call addlib_s,libsqlite,$(CONFIG_LIBSQLITE)))
 
 ################################################################################
-# Sources
+# Versioning and Paths
 ################################################################################
-LIBSQLITE_VERSION = 3400100
+LIBSQLITE_VERSION = 3450300
 LIBSQLITE_BASENAME = sqlite-amalgamation-$(LIBSQLITE_VERSION)
-LIBSQLITE_URL = https://www.sqlite.org/2022/$(LIBSQLITE_BASENAME).zip
-LIBSQLITE_PATCHDIR = $(LIBSQLITE_BASE)/patches
+LIBSQLITE_URL = https://www.sqlite.org/2024/$(LIBSQLITE_BASENAME).zip
+LIBSQLITE_PATCHDIR           = $(LIBSQLITE_BASE)/patches
+LIBSQLITE_SRC                = $(LIBSQLITE_ORIGIN)/$(LIBSQLITE_BASENAME)
+
 $(eval $(call fetch,libsqlite,$(LIBSQLITE_URL)))
 $(eval $(call patch,libsqlite,$(LIBSQLITE_PATCHDIR),$(LIBSQLITE_BASENAME)))
 
 ################################################################################
-# Helpers
+# Includes
 ################################################################################
-LIBSQLITE_SRC = $(LIBSQLITE_ORIGIN)/$(LIBSQLITE_BASENAME)
-
-################################################################################
-# Library includes
-################################################################################
-LIBSQLITE_CINCLUDES-y += -I$(LIBSQLITE_BASE)/include
-CINCLUDES-$(CONFIG_LIBSQLITE) += -I$(LIBSQLITE_SRC)
+CINCLUDES-$(CONFIG_LIBSQLITE)  += -I$(LIBSQLITE_SRC)
+CINCLUDES-$(CONFIG_LIBSQLITE)  += -I$(LIBSQLITE_BASE)/include
 CXXINCLUDES-$(CONFIG_LIBSQLITE) += -I$(LIBSQLITE_SRC)
 
 ################################################################################
-# Global flags
+# Flags
 ################################################################################
-LIBSQLITE_FLAGS = -D_HAVE_SQLITE_CONFIG_H -DSQLITE_OMIT_LOAD_EXTENSION
+LIBSQLITE_FLAGS = -D_HAVE_SQLITE_CONFIG_H \
+                  -DSQLITE_OMIT_LOAD_EXTENSION \
+                  -DSQLITE_OMIT_LOCALTIME \
+                  -DSQLITE_OS_UNIX=0 \
+                  -DSQLITE_OS_OTHER=1 \
+                  -DSQLITE_THREADSAFE=0
 
-# Suppress some warnings to make the build process look neater
-LIBSQLITE_SUPPRESS_FLAGS-y += -Wno-unused-parameter -Wno-unused-variable		\
--Wno-cast-function-type -Wno-char-subscripts
+LIBSQLITE_SUPPRESS_FLAGS-y += -Wno-unused-parameter \
+                              -Wno-unused-variable \
+                              -Wno-cast-function-type \
+                              -Wno-char-subscripts
 
-LIBSQLITE_SUPPRESS_FLAGS-$(call gcc_version_ge,7,0) +=-Wimplicit-fallthrough=0		\
+LIBSQLITE_SUPPRESS_FLAGS-$(call gcc_version_ge,7,0) += -Wimplicit-fallthrough=0
 
-LIBSQLITE_CFLAGS-y += $(LIBSQLITE_FLAGS)
-LIBSQLITE_CFLAGS-y += $(LIBSQLITE_SUPPRESS_FLAGS-y)
+CFLAGS-$(CONFIG_LIBSQLITE) += $(LIBSQLITE_FLAGS)
+CFLAGS-$(CONFIG_LIBSQLITE) += $(LIBSQLITE_SUPPRESS_FLAGS-y)
 
 ################################################################################
-# Glue code
+# Sources
 ################################################################################
-LIBSQLITE_SRCS-$(CONFIG_LIBSQLITE_MAIN_FUNCTION) += $(LIBSQLITE_BASE)/main.c|unikraft
-
-################################################################################
-# SQLite sources
-################################################################################
-LIBSQLITE_SHELL_FLAGS-y += -Dmain=sqlite_main -Dwmain=sqlite_main
-
-LIBSQLITE_SRCS-y += $(LIBSQLITE_SRC)/shell.c
 LIBSQLITE_SRCS-y += $(LIBSQLITE_SRC)/sqlite3.c
+
+# Optional: Shell support (CLI app interface, not needed for lib use)
+# Uncomment only if your app needs the shell interface (usually not)
+# LIBSQLITE_CFLAGS-y += -Dmain=sqlite_main -Dwmain=sqlite_main
+# LIBSQLITE_SRCS-y   += $(LIBSQLITE_SRC)/shell.c
+
+# Optional: Dummy main.c to satisfy Unikraft if needed
+# (Used only if library wants to override main())
+# LIBSQLITE_SRCS-$(CONFIG_LIBSQLITE_MAIN_FUNCTION) += $(LIBSQLITE_BASE)/main.c
+
+################################################################################
+# Object generation
+################################################################################
+LIBSQLITE_OBJS-y := $(LIBSQLITE_SRCS-y:.c=.o)
+$(eval $(call addlibobjs,libsqlite,$(LIBSQLITE_OBJS-y)))


### PR DESCRIPTION
This PR updates the lib-sqlite Unikraft library to SQLite version 3.50.1

Major changes:
Upgraded source to SQLite 3.50.1
Updated SHA256 hash accordingly for upstream zip
Patch 0001 disables `math.h` usage to ensure compatibility with Unikraft nolibc/libc
Patch 0002 stubs out unsupported POSIX syscalls (`close`, `access`, `getcwd`, `ftruncate`, `read`, `pread`)
Added wrapper header `sqlite_syswrap.h` and source `sqlite_syswrap.c`

### Notes

Initially targeted 3.45.3 when latest release was unavailable
Version 3.50.1 became stable after work had started — now upgraded
`math.h` dependency removed and syscalls stubbed via patches

Tested with `app-helloworld` on `qemu-x86_64`.